### PR TITLE
[NOT FOR MERGING] Make M1 friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,11 @@ RUN for t in deb deb-src; do \
         echo "$t [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/postgresql.keyring] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -s -c)-pgdg main" >> /etc/apt/sources.list.d/pgdg.list; \
     done
 
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN cp /etc/apt/sources.list /etc/apt/sources.list~
+RUN sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+
 RUN apt-get clean
 RUN apt-get update
 
@@ -126,7 +131,7 @@ RUN for pg in ${PG_VERSIONS}; do \
 
 
 RUN for pg in ${PG_VERSIONS}; do \
-        apt-get install -y postgresql-${pg} postgresql-${pg}-dbgsym postgresql-plpython3-${pg} postgresql-plperl-${pg} postgresql-server-dev-${pg} \
+        apt-get install -y postgresql-${pg} postgresql-plpython3-${pg} postgresql-plperl-${pg} postgresql-server-dev-${pg} \
             postgresql-${pg}-pgextwlist postgresql-${pg}-hll postgresql-${pg}-pgrouting postgresql-${pg}-repack postgresql-${pg}-hypopg postgresql-${pg}-unit \
             postgresql-${pg}-pg-stat-kcache postgresql-${pg}-cron postgresql-${pg}-pldebugger || exit 1; \
     done

--- a/build_scripts/install_timescaledb-toolkit.sh
+++ b/build_scripts/install_timescaledb-toolkit.sh
@@ -45,26 +45,3 @@ __EOT__
     cargo run --manifest-path ../tools/post-install/Cargo.toml -- "/usr/lib/postgresql/${PGVERSION}/bin/pg_config"
     cd ..
 done
-
-# We want to enforce users that install toolkit 1.5+ when upgrading or reinstalling.
-# NOTE: This does not affect versions that have already been installed, it only blocks
-#       users from installing/upgrading to these versions
-for file in "/usr/share/postgresql/${PGVERSION}/extension/timescaledb_toolkit--"*.sql; do
-
-    base="${file%.sql}"
-    target_version="${base##*--}"
-    case "${target_version}" in
-        "1.4"|"1.3"|"1.3.1")
-            cat > "${file}" << __SQL__
-DO LANGUAGE plpgsql
-\$\$
-BEGIN
-    RAISE EXCEPTION 'TimescaleDB Toolkit version ${target_version} can not be installed. You can install TimescaleDB Toolkit 1.5.1 or higher';
-END;
-\$\$
-__SQL__
-            ;;
-        *)
-            ;;
-    esac
-done


### PR DESCRIPTION
The below builds an M1 friendly image. It removes a few extensions we don't care about (but includes `Postgis` and `TimescaleDB Toolkit`).

```
PG_MAJOR=13 PG_VERSIONS=13 PG_AUTH_MON="" PG_STAT_MONITOR="" PG_LOGERRORS="" TIMESCALE_PROMSCALE_EXTENSION="" TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS="" GITHUB_TAG=2.5.2  make build
```